### PR TITLE
Use correct connection sizes when associating Connectable objects wit…

### DIFF
--- a/src/bdhal/common/Bucket.h
+++ b/src/bdhal/common/Bucket.h
@@ -41,6 +41,15 @@ public:
     uint32_t GetNumDimensions() {
         return m_dims;
     }
+
+    ///
+    /// Returns size when used with a Connection
+    ///
+    /// \return Size used with a Connection
+    ///
+    uint32_t GetConnectionSize() {
+        return m_dims;
+    }
 private:
     /// Bucket name
     std::string m_label;

--- a/src/bdhal/common/Connectable.cpp
+++ b/src/bdhal/common/Connectable.cpp
@@ -13,6 +13,10 @@ uint32_t Connectable::GetNumDimensions() {
     throw std::logic_error("Cannot call Connectable::GetNumDimensions");
 }
 
+uint32_t Connectable::GetConnectionSize() {
+    throw std::logic_error("Cannot call Connectable::GetConnectionSize");
+}
+
 ConnectableInput::ConnectableInput() {
 }
 
@@ -23,6 +27,10 @@ uint32_t ConnectableInput::GetNumDimensions() {
     throw std::logic_error("Cannot call ConnectableInput::GetNumDimensions");
 }
 
+uint32_t ConnectableInput::GetConnectionSize() {
+    throw std::logic_error("Cannot call ConnectableInput::GetConnectionSize");
+}
+
 ConnectableOutput::ConnectableOutput() {
 }
 
@@ -31,6 +39,10 @@ ConnectableOutput::~ConnectableOutput() {
 
 uint32_t ConnectableOutput::GetNumDimensions() {
     throw std::logic_error("Cannot call ConnectableOutput::GetNumDimensions");
+}
+
+uint32_t ConnectableOutput::GetConnectionSize() {
+    throw std::logic_error("Cannot call ConnectableOutput::GetConnectionSize");
 }
 
 } // namespace bdhal

--- a/src/bdhal/common/Connectable.h
+++ b/src/bdhal/common/Connectable.h
@@ -21,6 +21,7 @@ public:
     Connectable& operator=(Connectable&&) = delete;
 
     virtual uint32_t GetNumDimensions();
+    virtual uint32_t GetConnectionSize();
 
 protected:
 };
@@ -39,6 +40,7 @@ public:
     ConnectableInput& operator=(ConnectableInput&&) = delete;
 
     virtual uint32_t GetNumDimensions();
+    virtual uint32_t GetConnectionSize();
 
 protected:
 };
@@ -57,6 +59,7 @@ public:
     ConnectableOutput& operator=(ConnectableOutput&&) = delete;
 
     virtual uint32_t GetNumDimensions();
+    virtual uint32_t GetConnectionSize();
 
 protected:
 };

--- a/src/bdhal/common/Connection.h
+++ b/src/bdhal/common/Connection.h
@@ -50,11 +50,11 @@ public:
             throw std::logic_error("Connection weights point to null pointer");
         }
 
-        if(m_src->GetNumDimensions() != m_weights->GetNumColumns()) {
+        if(m_src->GetConnectionSize() != m_weights->GetNumColumns()) {
             throw std::logic_error("Connection input dimensions != Weight columns");
         }
 
-        if (m_dest->GetNumDimensions() != m_weights->GetNumRows()) {
+        if (m_dest->GetConnectionSize() != m_weights->GetNumRows()) {
             throw std::logic_error("Connection output dimensions != Weight rows");
         }
 

--- a/src/bdhal/common/Input.h
+++ b/src/bdhal/common/Input.h
@@ -38,11 +38,20 @@ public:
     }
 
     ///
-    /// Returns label assigned to Input
+    /// Returns number of dimensions assigned to Input
     ///
     /// \return Number of dimensions assigned to Input
     ///
     uint32_t GetNumDimensions() {
+        return m_dims;
+    }
+
+    ///
+    /// Returns size when used with a Connection
+    ///
+    /// \return Size used with a Connection
+    ///
+    uint32_t GetConnectionSize() {
         return m_dims;
     }
 private:

--- a/src/bdhal/common/Network.cpp
+++ b/src/bdhal/common/Network.cpp
@@ -61,8 +61,8 @@ Connection* Network::CreateConnection( std::string name,
         sizeof(uint32_t));
 
     Weights<uint32_t>* weightMatrix = 
-        new pystorm::bdhal::Weights<uint32_t>(m, dest->GetNumDimensions(), 
-            src->GetNumDimensions());
+        new pystorm::bdhal::Weights<uint32_t>(m, dest->GetConnectionSize(), 
+            src->GetConnectionSize());
     
     Connection* newConnection = new Connection(name, src, 
         dest, weightMatrix);

--- a/src/bdhal/common/Output.h
+++ b/src/bdhal/common/Output.h
@@ -44,6 +44,15 @@ public:
     uint32_t GetNumDimensions() {
         return m_dims;
     }
+
+    ///
+    /// Returns size when used as an input to a Connection
+    ///
+    /// \return Size used as input to Connection
+    ///
+    uint32_t GetConnectionSize() {
+        return m_dims;
+    }
 private:
     /// Output name
     std::string m_label;

--- a/src/bdhal/common/Pool.h
+++ b/src/bdhal/common/Pool.h
@@ -76,6 +76,15 @@ public:
     }
 
     ///
+    /// Returns size when used with a Connection
+    ///
+    /// \return Size used with a Connection
+    ///
+    uint32_t GetConnectionSize() {
+        return m_num_neurons;
+    }
+
+    ///
     /// Returns the Pool width
     ///
     /// Returns std::logic_error if width is not (e.g. by calling SetSize or

--- a/src/bdhal/common/StateSpace.h
+++ b/src/bdhal/common/StateSpace.h
@@ -45,6 +45,15 @@ public:
     uint32_t GetNumDimensions() {
         return m_dims;
     }
+
+    ///
+    /// Returns size when used with a Connection
+    ///
+    /// \return Size used with a Connection
+    ///
+    uint32_t GetConnectionSize() {
+        return m_dims;
+    }
 private:
     /// StateSpace name
     std::string m_label;

--- a/test/bdhal/common/Connection_test.cpp
+++ b/test/bdhal/common/Connection_test.cpp
@@ -25,12 +25,12 @@ TEST(TESTConnection, testConstructionValidParams) {
     Bucket* _bucket2 = new Bucket(bucket2_label, bucket2_dims);
 
     uint32_t* m = (uint32_t*)
-        std::calloc((_pool->GetNumDimensions()*_bucket->GetNumDimensions()),         
+        std::calloc((_pool->GetConnectionSize()*_bucket->GetConnectionSize()),         
         sizeof(uint32_t));  
 
     Weights<uint32_t>* wMatrix =
-        new Weights<uint32_t>(m, _bucket->GetNumDimensions(),
-        _pool->GetNumDimensions());
+        new Weights<uint32_t>(m, _bucket->GetConnectionSize(),
+        _pool->GetConnectionSize());
 
     Connection* _conn1 = nullptr;
     Connection* _conn2 = nullptr;
@@ -121,12 +121,12 @@ TEST(TESTConnection, testGetLabel) {
     Bucket* _bucket = new Bucket(bucket_label, bucket_dims);
 
     uint32_t* m = (uint32_t*)
-        std::calloc((_pool->GetNumDimensions()*_bucket->GetNumDimensions()),         
+        std::calloc((_pool->GetConnectionSize()*_bucket->GetConnectionSize()),         
         sizeof(uint32_t));  
 
     Weights<uint32_t>* wMatrix =
-        new Weights<uint32_t>(m, _bucket->GetNumDimensions(),
-        _pool->GetNumDimensions());
+        new Weights<uint32_t>(m, _bucket->GetConnectionSize(),
+        _pool->GetConnectionSize());
 
     Connection* _conn1 = new Connection(conn_label, _pool, _bucket, 
         wMatrix);
@@ -149,12 +149,12 @@ TEST(TESTConnection, testGetSrc) {
     Bucket* _bucket = new Bucket(bucket_label, bucket_dims);
 
     uint32_t* m = (uint32_t*)
-        std::calloc((_pool->GetNumDimensions()*_bucket->GetNumDimensions()),         
+        std::calloc((_pool->GetConnectionSize()*_bucket->GetConnectionSize()),         
         sizeof(uint32_t));  
 
     Weights<uint32_t>* wMatrix =
-        new Weights<uint32_t>(m, _bucket->GetNumDimensions(),
-        _pool->GetNumDimensions());
+        new Weights<uint32_t>(m, _bucket->GetConnectionSize(),
+        _pool->GetConnectionSize());
 
     Connection* _conn1 = new Connection(conn_label, _pool, _bucket, 
         wMatrix);
@@ -177,12 +177,12 @@ TEST(TESTConnection, testGetDest) {
     Bucket* _bucket = new Bucket(bucket_label, bucket_dims);
 
     uint32_t* m = (uint32_t*)
-        std::calloc((_pool->GetNumDimensions()*_bucket->GetNumDimensions()),         
+        std::calloc((_pool->GetConnectionSize()*_bucket->GetConnectionSize()),         
         sizeof(uint32_t));  
 
     Weights<uint32_t>* wMatrix =
-        new Weights<uint32_t>(m, _bucket->GetNumDimensions(),
-        _pool->GetNumDimensions());
+        new Weights<uint32_t>(m, _bucket->GetConnectionSize(),
+        _pool->GetConnectionSize());
 
     Connection* _conn1 = new Connection(conn_label, _pool, _bucket, 
         wMatrix);

--- a/test/bdhal/common/Input_test.cpp
+++ b/test/bdhal/common/Input_test.cpp
@@ -52,6 +52,17 @@ TEST(TESTInput, testGetNumDims) {
     delete _in;
 }
 
+TEST(TESTInput, testGetConnectionSize) {
+    std::string label = "InputN";
+    uint32_t dims = 3;
+    Input * _in = new Input(label, dims);
+
+
+    EXPECT_EQ(_in->GetConnectionSize(),dims);
+
+    delete _in;
+}
+
 
 } // namespace bdhal
 } // namespace pystorm

--- a/test/bdhal/common/Network_test.cpp
+++ b/test/bdhal/common/Network_test.cpp
@@ -104,16 +104,16 @@ TEST(TESTNetwork, testCreateConnection) {
     EXPECT_EQ(_net->GetConnections().at(0)->GetSrc(), _pool);
     EXPECT_EQ(_net->GetConnections().at(0)->GetDest(), _bucket);
 
-    EXPECT_EQ(wMatrix->GetNumRows(),_bucket->GetNumDimensions());
-    EXPECT_EQ(wMatrix->GetNumColumns(),_pool->GetNumDimensions());
+    EXPECT_EQ(wMatrix->GetNumRows(),_bucket->GetConnectionSize());
+    EXPECT_EQ(wMatrix->GetNumColumns(),_pool->GetConnectionSize());
 
     uint32_t* m2 = (uint32_t*)
-        std::calloc((_pool->GetNumDimensions()*_bucket->GetNumDimensions()),         
+        std::calloc((_pool->GetConnectionSize()*_bucket->GetConnectionSize()),         
         sizeof(uint32_t));  
 
     Weights<uint32_t>* wMatrix2 =
-        new Weights<uint32_t>(m2, _bucket->GetNumDimensions(),
-        _pool->GetNumDimensions());
+        new Weights<uint32_t>(m2, _bucket->GetConnectionSize(),
+        _pool->GetConnectionSize());
 
     EXPECT_NO_THROW(_conn2 = _net->CreateConnection(conn2_label, _pool, _bucket,
         wMatrix2));
@@ -125,8 +125,8 @@ TEST(TESTNetwork, testCreateConnection) {
     EXPECT_EQ(_net->GetConnections().at(1)->GetSrc(), _pool);
     EXPECT_EQ(_net->GetConnections().at(1)->GetDest(), _bucket);
 
-    EXPECT_EQ(wMatrix->GetNumRows(),_bucket->GetNumDimensions());
-    EXPECT_EQ(wMatrix->GetNumColumns(),_pool->GetNumDimensions());
+    EXPECT_EQ(wMatrix->GetNumRows(),_bucket->GetConnectionSize());
+    EXPECT_EQ(wMatrix->GetNumColumns(),_pool->GetConnectionSize());
    
     delete _conn2;
     delete _conn;

--- a/test/bindings/python/3_5/PyStorm_test.py
+++ b/test/bindings/python/3_5/PyStorm_test.py
@@ -183,9 +183,60 @@ class TestConnection(unittest.TestCase):
     weights_3_3 = ps.Weights([[1,2,3],
                               [4,5,6],
                               [7,8,9]])
+
+    weights_20_3 = ps.Weights([[1,2,3],
+                              [4,5,6],
+                              [7,8,9],
+                              [10,11,12],
+                              [13,14,15],
+                              [16,17,18],
+                              [19,20,21],
+                              [22,23,24],
+                              [25,26,27],
+                              [28,29,30],
+                              [31,32,33],
+                              [34,35,36],
+                              [37,38,39],
+                              [40,41,42],
+                              [43,44,45],
+                              [46,47,48],
+                              [49,50,51],
+                              [52,53,54],
+                              [55,56,57],
+                              [58,59,60]])
+
+    weights_20_2 = ps.Weights([[1,2],
+                              [4,5],
+                              [7,8],
+                              [10,11],
+                              [13,14],
+                              [16,17],
+                              [19,20],
+                              [22,23],
+                              [25,26],
+                              [28,29],
+                              [31,32],
+                              [34,35],
+                              [37,38],
+                              [40,41],
+                              [43,44],
+                              [46,47],
+                              [49,50],
+                              [52,53],
+                              [55,56],
+                              [58,59]])
+
+    weights_3_20 = ps.Weights([[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20],
+                              [21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40],
+                              [41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60]])
+
+    weights_2_20 = ps.Weights([[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20],
+                              [21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40]])
+
     weights_2_3 = ps.Weights([[1,2],
                               [4,5],
                               [7,8]])
+
     weights_3_2 = ps.Weights([[1,2,3],
                               [4,5,6]])
 
@@ -193,11 +244,11 @@ class TestConnection(unittest.TestCase):
         try:
             raised = False
             conn = ps.Connection("conn", self.conn_in[0], self.pool[0], 
-                self.weights_3_3)
+                self.weights_20_3)
             conn = ps.Connection("conn", self.conn_in[0], self.pool[1], 
-                self.weights_3_2)
+                self.weights_20_3)
             conn = ps.Connection("conn", self.conn_in[1], self.pool[0],     
-                self.weights_2_3)
+                self.weights_20_2)
             conn = ps.Connection("conn", self.conn_in[0], self.pool[1])
             conn = ps.Connection("conn", self.conn_in[1], self.pool[0])
         except:
@@ -217,11 +268,11 @@ class TestConnection(unittest.TestCase):
         try:
             raised = False
             conn = ps.Connection("conn", self.pool[0], self.bucket[0], 
-                self.weights_3_3)
+                self.weights_3_20)
             conn = ps.Connection("conn", self.pool[0], self.bucket[1], 
-                self.weights_3_2)
+                self.weights_2_20)
             conn = ps.Connection("conn", self.pool[1], self.bucket[0], 
-                self.weights_2_3)
+                self.weights_3_20)
             conn = ps.Connection("conn", self.pool[0], self.bucket[1]) 
             conn = ps.Connection("conn", self.pool[1], self.bucket[0]) 
         except:
@@ -303,13 +354,13 @@ class TestConnection(unittest.TestCase):
         
     def test_get_label(self):
         conn = ps.Connection("conn", self.conn_in[0], self.pool[0], 
-            self.weights_3_3)
+            self.weights_20_3)
 
         self.assertEqual("conn",conn.get_label())
 
     def test_get_source(self):
         conn = ps.Connection("conn", self.conn_in[0], self.pool[0], 
-            self.weights_3_3)
+            self.weights_20_3)
 
         self.assertEqual(self.conn_in[0].get_label(),
             conn.get_source().get_label())
@@ -318,7 +369,7 @@ class TestConnection(unittest.TestCase):
 
     def test_get_dest(self):
         conn = ps.Connection("conn", self.conn_in[0], self.pool[0], 
-            self.weights_3_3)
+            self.weights_20_3)
 
         self.assertEqual(self.pool[0].get_label(),
             conn.get_dest().get_label())
@@ -329,13 +380,13 @@ class TestConnection(unittest.TestCase):
 
     def test_get_weights(self):
         conn = ps.Connection("conn", self.conn_in[0], self.pool[0], 
-            self.weights_3_3)
+            self.weights_20_3)
 
         weights = conn.get_weights()
 
         for i in range(weights.get_num_rows()):
             for j in range(weights.get_num_columns()):
-                self.assertEqual(self.weights_3_3.get_element(i,j),weights.get_element(i,j))
+                self.assertEqual(self.weights_20_3.get_element(i,j),weights.get_element(i,j))
 
     def test_set_weights(self):
         conn = ps.Connection("conn", self.conn_in[0], self.pool[0])
@@ -343,13 +394,13 @@ class TestConnection(unittest.TestCase):
 
         self.assertEqual(weights,None)
 
-        conn.set_weights(self.weights_3_3)
+        conn.set_weights(self.weights_20_3)
 
         weights = conn.get_weights()
 
         for i in range(weights.get_num_rows()):
             for j in range(weights.get_num_columns()):
-                self.assertEqual(self.weights_3_3.get_element(i,j),weights.get_element(i,j))
+                self.assertEqual(self.weights_20_3.get_element(i,j),weights.get_element(i,j))
 
 class TestNetwork(unittest.TestCase):
     num_neurons = 100


### PR DESCRIPTION
…h Connection objects 

This pull request addresses issue #39 

When connecting a Pool to a Bucket with a Connection object, we found out
that the connection was using the Pools dimensions and the Buckets dimensions
as the required dimensions of Connection objects weight matrix.

This was incorrect.

The Pools number of neurons indicates the input dimenions of the Connection
object and the weight matrix's number of columns should equal the
Pools number of neurons.

If a Pool is the input to a Connection, the number of neurons is the Connections
input size. If the input to a Connection is an Input or Bucket, the objects
number of dimensions is the Connections input size. To implement this requirement,
the Connection interface was given a GetConnectionSize method and the Pool
class returns the number of neurons whereas the other Connectable objects
return the number of dimensions.