### PR TITLE
Initial versions of pure-Python graph components

### DIFF
--- a/src/neuromorph/neuromorph/graph/__init__.py
+++ b/src/neuromorph/neuromorph/graph/__init__.py
@@ -1,0 +1,5 @@
+from . import network
+
+
+def create_network(label):
+    return network.Network(label)

--- a/src/neuromorph/neuromorph/graph/bucket.py
+++ b/src/neuromorph/neuromorph/graph/bucket.py
@@ -1,0 +1,10 @@
+class Bucket(object):
+    def __init__(self, label, dimensions):
+        self.label = label
+        self.dimensions = dimensions
+
+    def get_label(self):
+        return self.label
+
+    def get_num_dimensions(self):
+        return self.dimensions

--- a/src/neuromorph/neuromorph/graph/connection.py
+++ b/src/neuromorph/neuromorph/graph/connection.py
@@ -1,0 +1,18 @@
+class Connection(object):
+    def __init__(self, label, src, dest, weights):
+        self.label = label
+        self.src = src
+        self.dest = dest
+        self.weights = weights
+
+    def get_label(self):
+        return self.label
+
+    def get_weights(self):
+        return self.weights
+
+    def get_source(self):
+        return self.src
+
+    def get_dest(self):
+        return self.dest

--- a/src/neuromorph/neuromorph/graph/input.py
+++ b/src/neuromorph/neuromorph/graph/input.py
@@ -1,0 +1,10 @@
+class Input(object):
+    def __init__(self, label, dimensions):
+        self.label = label
+        self.dimensions = dimensions
+
+    def get_label(self):
+        return self.label
+
+    def get_num_dimensions(self):
+        return self.dimensions

--- a/src/neuromorph/neuromorph/graph/network.py
+++ b/src/neuromorph/neuromorph/graph/network.py
@@ -1,0 +1,58 @@
+from . import bucket
+from . import pool
+from . import input
+from . import output
+from . import connection
+
+
+class Network(object):
+    def __init__(self, label):
+        self.label = label
+        self.buckets = []
+        self.pools = []
+        self.inputs = []
+        self.outputs = []
+        self.connections = []
+
+    def get_label(self):
+        return label
+
+    def get_buckets(self):
+        return self.buckets
+
+    def get_pools(self):
+        return self.pools
+
+    def get_inputs(self):
+        return self.inputs
+
+    def get_outputs(self):
+        return self.outputs
+
+    def get_connections(self):
+        return self.connections
+
+    def create_pool(self, label, n_neurons, dimensions):
+        p = pool.Pool(label, n_neurons, dimensions)
+        self.pools.append(p)
+        return p
+
+    def create_input(self, label, dimensions):
+        i = input.Input(label, dimensions)
+        self.inputs.append(i)
+        return i
+
+    def create_connection(self, label, src, dest, weights):
+        c = connection.Connection(label, src, dest, weights)
+        self.connections.append(c)
+        return c
+
+    def create_bucket(self, label, dimensions):
+        b = bucket.Bucket(label, dimensions)
+        self.buckets.append(b)
+        return b
+
+    def create_output(self, label, dimensions):
+        o = output.Output(label, dimensions)
+        self.outputs.append(o)
+        return o

--- a/src/neuromorph/neuromorph/graph/output.py
+++ b/src/neuromorph/neuromorph/graph/output.py
@@ -1,0 +1,10 @@
+class Output(object):
+    def __init__(self, label, dimensions):
+        self.label = label
+        self.dimensions = dimensions
+
+    def get_label(self):
+        return self.label
+
+    def get_num_dimensions(self):
+        return self.dimensions

--- a/src/neuromorph/neuromorph/graph/pool.py
+++ b/src/neuromorph/neuromorph/graph/pool.py
@@ -1,0 +1,14 @@
+class Pool(object):
+    def __init__(self, label, n_neurons, dimensions):
+        self.label = label
+        self.n_neurons = n_neurons
+        self.dimensions = dimensions
+
+    def get_label(self):
+        return self.label
+
+    def get_num_dimensions(self):
+        return self.dimensions
+
+    def get_num_neurons(self):
+        return self.n_neurons


### PR DESCRIPTION
Here's a quick minimal implementation of the Pystorm.Network object graph.  

This minimal implementation works as a complete replacement for what I was using `Pystorm.create_network` for.  I can use it to define all the components in a converted Nengo model, and I can traverse the graph afterwards to generate displays of the graph structure itself  (example: https://github.com/ctn-waterloo/nengo_brainstorm/blob/master/examples/Plotting%20Networks.ipynb )

My next steps are to add some testing and some sanity checks to the system (e.g. making sure that the src and dest of a connection are the correct size, and are actually in the Network).  But I figured I should post this initial version just in case there are fundamental problems with how I'm doing this.